### PR TITLE
feat(tp2): rutina ASM + Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 .DS_Store
 
 # Archivos compilados C
+build/
 *.o
 *.so
 

--- a/TP2/stackframe/Makefile
+++ b/TP2/stackframe/Makefile
@@ -1,0 +1,128 @@
+# =========================
+# Configuración
+# =========================
+
+CC = gcc
+AS = as
+
+CFLAGS = -g -O0
+PICFLAGS = -fPIC
+
+SRC_DIR = codigo
+BUILD_DIR = build
+
+# =========================
+# Archivos
+# =========================
+
+MAIN_C = $(SRC_DIR)/main.c
+MAIN_ASM_C = $(SRC_DIR)/main_asm.c
+PROC_C = $(SRC_DIR)/procesar.c
+PROC_ASM = $(SRC_DIR)/procesar.s
+
+MAIN_O = $(BUILD_DIR)/main.o
+MAIN_ASM_O = $(BUILD_DIR)/main_asm.o
+PROC_O = $(BUILD_DIR)/procesar.o
+PROC_ASM_O = $(BUILD_DIR)/procesar_asm.o
+
+LIB = $(BUILD_DIR)/libprocesar.so
+BIN = $(BUILD_DIR)/programa
+BIN_ASM = $(BUILD_DIR)/programa_asm
+
+PY_API = $(SRC_DIR)/gini_api.py
+PY_CTYPES = $(SRC_DIR)/gini_ctypes.py
+
+# =========================
+# Targets principales
+# =========================
+
+all: c
+
+# Crear carpeta build automáticamente
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+# -------------------------
+# Iteración 1: solo C
+# -------------------------
+
+c: $(BIN)
+
+$(BIN): $(MAIN_O) $(PROC_O)
+	$(CC) $(CFLAGS) -o $(BIN) $(MAIN_O) $(PROC_O)
+
+$(MAIN_O): $(MAIN_C) | $(BUILD_DIR)
+	$(CC) $(CFLAGS) -c $(MAIN_C) -o $(MAIN_O)
+
+$(PROC_O): $(PROC_C) | $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(PICFLAGS) -c $(PROC_C) -o $(PROC_O)
+
+run-c: c
+	./$(BIN)
+
+# -------------------------
+# Iteración 2: C + ASM
+# -------------------------
+
+asm: $(BIN_ASM)
+
+$(BIN_ASM): $(MAIN_ASM_O) $(PROC_ASM_O)
+	$(CC) $(CFLAGS) -o $(BIN_ASM) $(MAIN_ASM_O) $(PROC_ASM_O)
+
+$(MAIN_ASM_O): $(MAIN_ASM_C) | $(BUILD_DIR)
+	$(CC) $(CFLAGS) -c $(MAIN_ASM_C) -o $(MAIN_ASM_O)
+
+$(PROC_ASM_O): $(PROC_ASM) | $(BUILD_DIR)
+	$(AS) --64 -g -o $(PROC_ASM_O) $(PROC_ASM)
+
+run-asm: asm
+	./$(BIN_ASM)
+
+# -------------------------
+# Librería para ctypes
+# -------------------------
+
+lib: $(LIB)
+
+$(LIB): $(PROC_O)
+	$(CC) -shared -o $(LIB) $(PROC_O)
+
+run-py: lib
+	python $(PY_CTYPES)
+
+run-api:
+	python $(PY_API)
+
+# -------------------------
+# Debug
+# -------------------------
+
+debug-c: c
+	gdb ./$(BIN)
+
+debug-asm: asm
+	gdb ./$(BIN_ASM)
+
+# -------------------------
+# Limpieza
+# -------------------------
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+# -------------------------
+# Ayuda
+# -------------------------
+
+help:
+	@echo "Targets disponibles:"
+	@echo "  make c        -> Compila versión en C"
+	@echo "  make asm      -> Compila versión ASM"
+	@echo "  make lib      -> Genera libprocesar.so"
+	@echo "  make run-c    -> Ejecuta programa en C"
+	@echo "  make run-asm  -> Ejecuta programa ASM"
+	@echo "  make run-py   -> Ejecuta Python + ctypes"
+	@echo "  make run-api  -> Ejecuta solo consulta API"
+	@echo "  make debug-c  -> Debug C con GDB"
+	@echo "  make debug-asm-> Debug ASM con GDB"
+	@echo "  make clean    -> Limpia archivos generados"

--- a/TP2/stackframe/README.md
+++ b/TP2/stackframe/README.md
@@ -1,6 +1,6 @@
 # Stackframe - Guía de compilación y ejecución
 
-Según lo indicado en el documento [TP calculadora de inidces GINI](https://docs.google.com/document/d/1iR36JSzibt84sx7Pg65Ty6jhb3hQ4PmNnv7oCygqSwY/edit?tab=t.0#heading=h.l9frjjl9vc9b)
+Según lo indicado en el documento [TP calculadora de indices GINI](https://docs.google.com/document/d/1iR36JSzibt84sx7Pg65Ty6jhb3hQ4PmNnv7oCygqSwY/edit?tab=t.0#heading=h.l9frjjl9vc9b)
 
 ---
 
@@ -60,8 +60,8 @@ pip install requests
 ### Ejecutar scripts
 
 ```bash
-python gini_api.py
-python gini_ctypes.py
+python codigo/gini_api.py
+python codigo/gini_ctypes.py
 ```
 
 ### Salir del entorno
@@ -74,15 +74,19 @@ deactivate
 
 ---
 
-# 3. Estructura esperada
+# 3. Estructura del proyecto
 
 ```
 codigo/
   main.c
-  procesar.c      ← implementación en C (iteración 1)
-  procesar.asm    ← implementación en ASM (iteración 2)
-  gini_api.py     ← consulta a la API
-  gini_ctypes.py  ← integración Python - C
+  main_asm.c
+  procesar.c          ← implementación en C (iteración 1)
+  procesar.s          ← implementación en ASM (iteración 2)
+  procesar_wrapper.c  ← wrapper C → ASM
+  gini_api.py
+  gini_ctypes.py
+
+build/                ← archivos generados (no versionados)
 ```
 
 ---
@@ -92,7 +96,13 @@ codigo/
 ## Iteración 1 (solo C)
 
 ```bash
-gcc codigo/main.c codigo/procesar.c -o programa
+gcc codigo/main.c codigo/procesar.c -o build/programa
+```
+
+Ejecutar:
+
+```bash
+./build/programa
 ```
 
 ---
@@ -100,44 +110,72 @@ gcc codigo/main.c codigo/procesar.c -o programa
 ## Iteración 2 (C + ASM)
 
 ```bash
-gcc -c codigo/procesar.asm -o procesar.o
-gcc -c codigo/main.c -o main.o
-gcc main.o procesar.o -o programa
+as --64 -g -o build/procesar.o codigo/procesar.s
+gcc -g -O0 -c codigo/main_asm.c -o build/main_asm.o
+gcc build/main_asm.o build/procesar.o -o build/programa_asm
 ```
 
-> Nota: según la sintaxis usada, el archivo ASM puede necesitar extensión `.s` en lugar de `.asm`.
-
----
-
-# 5. Compilación como librería compartida (para Python)
-
-Para usar la función de C desde Python con `ctypes`, se debe compilar como librería dinámica.
-
-### Paso 1: generar objeto
-```bash
-gcc -c procesar.c -o procesar.o
-```
-
-### Paso 2: generar librería
-```bash
-gcc -shared -W -o libprocesar.so procesar.o
-```
-
-Esto genera `libprocesar.so`
-
----
-
-# 6. Ejecución con Python + C
-
-Asegurarse de que `libprocesar.so` esté en el mismo directorio que el script o indicar la ruta correcta.
+Ejecutar:
 
 ```bash
-python gini_ctypes.py
+./build/programa_asm
 ```
 
 ---
 
-# 7. Notas importantes
-- No se versionan archivos compilados (.o, .so)
-- La librería debe generarse en cada entorno
-- Si no existe `libprocesar.so`, la ejecución en Python fallará
+# 5. Librería compartida (C → ASM → Python)
+
+## Compilación manual
+
+```bash
+as --64 -g -o build/procesar.o codigo/procesar.s
+gcc -g -O0 -fPIC -c codigo/procesar_wrapper.c -o build/wrapper.o
+gcc -shared -o build/libprocesar.so build/procesar.o build/wrapper.o
+```
+
+---
+
+# 6. Ejecución Python + C + ASM
+
+El script Python debe cargar la librería desde `build/`.
+
+Ejecutar:
+
+```bash
+python codigo/gini_ctypes.py
+```
+
+---
+
+# 7. Uso con Makefile
+
+Alternativa recomendada:
+
+```bash
+make run-c
+make run-asm
+make run-py
+```
+
+---
+
+# 8. Debug con GDB
+
+```bash
+gdb ./build/programa
+gdb ./build/programa_asm
+```
+
+---
+
+# 9. Notas importantes
+
+* No versionar archivos compilados:
+
+  * `.o`
+  * `.so`
+  * binarios
+* La carpeta `build/` está en `.gitignore`
+* La librería `libprocesar.so` debe generarse localmente
+* Si la librería no existe, Python fallará al cargarla
+* El código ASM debe respetar la convención **System V AMD64 ABI**

--- a/TP2/stackframe/codigo/gini_ctypes.py
+++ b/TP2/stackframe/codigo/gini_ctypes.py
@@ -2,7 +2,7 @@ from gini_api import obtener_gini_argentina
 import ctypes
 
 # cargar librería compartida
-lib = ctypes.CDLL("./libprocesar.so")
+lib = ctypes.CDLL("./build/libprocesar.so")
 
 # definir tipos
 lib.procesar.argtypes = [ctypes.c_float]

--- a/TP2/stackframe/codigo/main_asm.c
+++ b/TP2/stackframe/codigo/main_asm.c
@@ -1,0 +1,26 @@
+#include <stdio.h>
+
+int procesar(float x);  // prototipo ASM
+
+int main() {
+    float valores[] = {3.7, 2.1, -1.9, 0.0};
+
+    for (int i = 0; i < 4; i++) {
+        int r = procesar(valores[i]);
+        printf("x = %.2f → resultado = %d\n", valores[i], r);
+    }
+
+    float input;
+
+    printf("\nIngrese un número: ");
+    if(scanf("%f", &input) != 1) {
+        printf("Error al leer el valor\n");
+        return 1;
+    }
+
+    int resultado = procesar(input);
+
+    printf("Resultado: %d\n", resultado);
+
+    return 0;
+}

--- a/TP2/stackframe/codigo/procesar.s
+++ b/TP2/stackframe/codigo/procesar.s
@@ -1,0 +1,16 @@
+# procesar.s  —  función procesar(float x) en AT&T syntax
+# Convención System V AMD64 ABI:
+#   %xmm0 = 1er argumento (float x)
+#   %eax = valor de retorno (int de 32 bits)
+
+.section .text
+.globl  procesar       # exportar símbolo para el linker
+.type   procesar, @function
+
+procesar:
+    # Prólogo — no necesitamos frame propio para esta función simple
+    cvttss2si   %xmm0, %eax     # truncar float a int (32 bits)
+    addl        $1   , %eax     # eax = a + 1
+    ret                         # retorna
+
+.size   procesar, .-procesar


### PR DESCRIPTION
## Resumen

Se implementa la base del TP2 siguiendo el enfoque incremental:

- Rutina en ensamblador (procesar.s)
- Programa de prueba en C (main_asm.c)
- Makefile unificado para build, ejecución y debug
- Ajuste de integración Python (ctypes)
- Actualización de documentación (README)
- Configuración de .gitignore

---

## Cambios incluidos

### ASM
- Implementación de `procesar` en ensamblador
- Conversión float → int + suma de 1
- Uso de convención System V AMD64 ABI

### C
- `main_asm.c` para testear la rutina ASM
- Validación de funcionamiento desde C

### Build
- Se agrega Makefile con:
  - targets para C y ASM
  - generación de `.so`
  - ejecución de Python
  - debug con GDB
- Uso de carpeta `build/` para artefactos

### Python
- Corrección de ruta de carga de `libprocesar.so`

### Documentación
- README actualizado con:
  - estructura del proyecto
  - pasos de compilación
  - flujo general del TP

### Repo
- `.gitignore` actualizado:
  - build/
  - archivos compilados

---

## Estado actual

✔ Iteración 1 completa (C)  
✔ Iteración 2 ASM funcional desde C  
✔ Integración Python preparada (sin wrapper aún)

---

## Pendiente (siguiente PR)

- Wrapper en C (C → ASM)
- Integración completa Python → C → ASM
- Validación final del flujo completo

---

## Cómo probar

### Compilar ASM
```bash
make run-asm
```

### Ejecutar Python

```bash
make run-py
```

---

## Issue relacionado
Closes #10 