### PR TITLE
feat(tp2): integración completa Python → C (wrapper) → ASM

### DIFF
--- a/TP2/stackframe/Makefile
+++ b/TP2/stackframe/Makefile
@@ -19,11 +19,13 @@ MAIN_C = $(SRC_DIR)/main.c
 MAIN_ASM_C = $(SRC_DIR)/main_asm.c
 PROC_C = $(SRC_DIR)/procesar.c
 PROC_ASM = $(SRC_DIR)/procesar.s
+WRAPPER_C = $(SRC_DIR)/procesar_wrapper.c
 
 MAIN_O = $(BUILD_DIR)/main.o
 MAIN_ASM_O = $(BUILD_DIR)/main_asm.o
 PROC_O = $(BUILD_DIR)/procesar.o
 PROC_ASM_O = $(BUILD_DIR)/procesar_asm.o
+WRAPPER_O = $(BUILD_DIR)/wrapper.o
 
 LIB = $(BUILD_DIR)/libprocesar.so
 BIN = $(BUILD_DIR)/programa
@@ -31,6 +33,8 @@ BIN_ASM = $(BUILD_DIR)/programa_asm
 
 PY_API = $(SRC_DIR)/gini_api.py
 PY_CTYPES = $(SRC_DIR)/gini_ctypes.py
+
+.PHONY: all c asm lib run-c run-asm run-py run-api clean help debug-c debug-asm
 
 # =========================
 # Targets principales
@@ -79,13 +83,16 @@ run-asm: asm
 	./$(BIN_ASM)
 
 # -------------------------
-# Librería para ctypes
+# Librería para ctypes (C wrapper + ASM)
 # -------------------------
 
 lib: $(LIB)
 
-$(LIB): $(PROC_O)
-	$(CC) -shared -o $(LIB) $(PROC_O)
+$(WRAPPER_O): $(WRAPPER_C) | $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(PICFLAGS) -c $(WRAPPER_C) -o $(WRAPPER_O)
+
+$(LIB): $(PROC_ASM_O) $(WRAPPER_O)
+	$(CC) -shared -o $(LIB) $(PROC_ASM_O) $(WRAPPER_O)
 
 run-py: lib
 	python $(PY_CTYPES)
@@ -118,10 +125,10 @@ help:
 	@echo "Targets disponibles:"
 	@echo "  make c        -> Compila versión en C"
 	@echo "  make asm      -> Compila versión ASM"
-	@echo "  make lib      -> Genera libprocesar.so"
+	@echo "  make lib      -> Genera libprocesar.so (C wrapper + ASM)"
 	@echo "  make run-c    -> Ejecuta programa en C"
 	@echo "  make run-asm  -> Ejecuta programa ASM"
-	@echo "  make run-py   -> Ejecuta Python + ctypes"
+	@echo "  make run-py   -> Ejecuta Python → C → ASM"
 	@echo "  make run-api  -> Ejecuta solo consulta API"
 	@echo "  make debug-c  -> Debug C con GDB"
 	@echo "  make debug-asm-> Debug ASM con GDB"

--- a/TP2/stackframe/README.md
+++ b/TP2/stackframe/README.md
@@ -88,6 +88,62 @@ codigo/
 
 build/                ← archivos generados (no versionados)
 ```
+---
+
+## 3.1 Flujo de ejecución
+
+El sistema completo sigue el siguiente flujo:
+
+```text
+Python → ctypes → wrapper en C → rutina en ASM
+```
+
+Detalle:
+
+- Python obtiene los datos desde la API (GINI)
+- `ctypes` carga la librería compartida (`.so`)
+- Se invoca una función del wrapper en C
+- El wrapper llama a la rutina en ensamblador
+- El resultado vuelve a Python
+
+---
+
+## 3.2 Interfaz entre componentes
+
+### ASM
+
+La rutina en ensamblador:
+
+```c
+int procesar(float x);
+```
+
+Convención:
+- argumento en %xmm0
+- retorno en %eax
+
+### Wrapper en C
+
+El wrapper adapta la función ASM para Python:
+
+```c
+int procesar_wrapper(float x);
+```
+
+Responsabilidades:
+
+- recibir `float` desde Python
+- llamar a la función ASM
+- devolver `int`
+
+### Python (ctypes)
+
+Se define la firma:
+
+```python
+lib.procesar_wrapper.argtypes = [ctypes.c_float]
+lib.procesar_wrapper.restype = ctypes.c_int
+```
 
 ---
 

--- a/TP2/stackframe/codigo/gini_ctypes.py
+++ b/TP2/stackframe/codigo/gini_ctypes.py
@@ -4,13 +4,13 @@ import ctypes
 # cargar librería compartida
 lib = ctypes.CDLL("./build/libprocesar.so")
 
-# definir tipos
-lib.procesar.argtypes = [ctypes.c_float]
-lib.procesar.restype = ctypes.c_int
+# definir tipos (wrapper C)
+lib.procesar_wrapper.argtypes = [ctypes.c_float]
+lib.procesar_wrapper.restype = ctypes.c_int
 
 # Wrapper para llamar a la función de C
 def procesar(x):
-    return lib.procesar(x)
+    return lib.procesar_wrapper(x)
 
 def main():
     datos = obtener_gini_argentina()

--- a/TP2/stackframe/codigo/procesar_wrapper.c
+++ b/TP2/stackframe/codigo/procesar_wrapper.c
@@ -1,0 +1,7 @@
+// declara la función ASM
+int procesar(float x);
+
+// wrapper que será visible para Python
+int procesar_wrapper(float x) {
+    return procesar(x);
+}


### PR DESCRIPTION
## Cambios incluidos

### C
- Se agrega `procesar_wrapper.c`
- Wrapper que encapsula la llamada a ASM
- Interfaz limpia para ser utilizada desde Python

### Build
- Makefile actualizado:
  - `libprocesar.so` ahora se genera a partir de ASM + wrapper
  - Eliminado uso de `procesar.c` en la librería
  - Soporte completo para flujo Python → C → ASM

### Python
- Integración con ctypes usando `procesar_wrapper`

### Documentación
- README actualizado con:
  - nueva estructura del proyecto
  - pasos de compilación
  - flujo completo de ejecución

---

## Estado del TP

✔ Iteración 1: C  
✔ Iteración 2: ASM

---

## Cómo probar

### Compilar y ejecutar ASM
```bash
make run-asm
```

### Ejecutar integración completa
```bash
make run-py
```

## Issue relacionado

Closes #11 